### PR TITLE
Added a rm for SimNetworkSeriesObj

### DIFF
--- a/R/gof.ergmm.R
+++ b/R/gof.ergmm.R
@@ -173,6 +173,9 @@ gof.ergmm <- function (object, ..., nsim=100,
     }
   }
 
+  # Free up some space in the resulting object
+  rm(SimNetworkSeriesObj)
+	
   # calculate p-values
 
  if ('model' %in% all.gof.vars) {


### PR DESCRIPTION
Removing SimNetworkSeriesObj saves a lot of memory in the resulting object.  See the statnet_help exchange here: http://mailman13.u.washington.edu/mailman/htdig/statnet_help/2014/001878.html